### PR TITLE
githubreviewを日本語でしてもらうようPRテンプレートを変更 #18

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- I want to review in Japanese. -->
 ## 関連Issue
 <!-- #の後ろに対応するissue番号を書く -->
 Closes #
@@ -9,3 +10,15 @@ Closes #
 - [ ] ビルドできた
 
 ## 参考にした資料
+
+<!-- for GitHub Copilot review rule -->
+レビューに関して
+レビューする際には、以下のprefix(接頭辞)を付けてください。
+[must] → かならず変更してね
+[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
+[nits] → ささいな指摘(nitpick)
+[ask] → 質問
+[fyi] → 参考情報
+<!-- for GitHub Copilot review  rule-->
+
+<!-- I want to review in Japanese. -->


### PR DESCRIPTION
## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #18 

## やったこと
githubに日本語でレビューしてもらうためにPRテンプレートに文言を追加
PRテンプレートが汚れてしまうので嫌だったが、以下の参考資料の通りに有料のgithubリポジトリ等じゃないと対応していないらしいのでPRテンプレートに記載

## 動作確認
<!-- テスト内容など -->
- [x] ビルドできた

## 参考にした資料
https://zenn.dev/gmomedia/articles/copilot-japanese-review-tips
https://qiita.com/Fukuda716/items/106bf2b37dbdad077a93
