### PR TITLE
docs配下の整備ドキュメント量を最小限に #22

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,10 +5,7 @@
   "proseWrap": "preserve",
   "overrides": [
     {
-      "files": "*.md",
-      "options": {
-        "proseWrap": "preserve"
-      }
+      "files": "*.md"
     }
   ]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
+  "proseWrap": "preserve",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "proseWrap": "preserve"
+      }
+    }
+  ]
+}

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -8,12 +8,15 @@
 | A2  | POST   | /auth/login              | ログイン                     | なし   |
 | A3  | POST   | /auth/refresh            | リフレッシュトークンで再発行 | なし   |
 | U1  | GET    | /users/me                | 自分のプロフィール取得       | 要 JWT |
-| U2  | PATCH  | /users/me                | 自分のプロフィール更新       | 要 JWT |
+| U2  | PUT    | /users/me                | 自分のプロフィール更新       | 要 JWT |
+| U3  | POST   | /users/me/avatar         | アイコン画像アップロード     | 要 JWT |
+| U4  | DELETE | /users/me/avatar         | アイコン削除                 | 要 JWT |
+| U5  | GET    | /users/{userId}          | 他ユーザーのプロフィール取得 | なし   |
 | P1  | POST   | /posts                   | 汚部屋投稿作成（写真＋説明） | 要 JWT |
-| P2  | GET    | /posts                   | 投稿一覧                     | 任意   |
-| P3  | GET    | /posts/{postId}          | 投稿詳細                     | 任意   |
+| P2  | GET    | /posts                   | 投稿一覧                     | なし   |
+| P3  | GET    | /posts/{postId}          | 投稿詳細                     | なし   |
 | P4  | DELETE | /posts/{postId}          | 自分の投稿削除               | 要 JWT |
 | R2  | GET    | /posts/{postId}/ratings  | 平均評価取得                 | 要 JWT |
 | C1  | POST   | /posts/{postId}/comments | コメント作成                 | 要 JWT |
-| C2  | GET    | /posts/{postId}/comments | コメント一覧                 | 任意   |
+| C2  | GET    | /posts/{postId}/comments | コメント一覧                 | なし   |
 | H1  | GET    | /health                  | ヘルスチェック               | なし   |

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -1,0 +1,19 @@
+# API エンドポイント一覧
+
+`/api/v1` 配下の REST エンドポイント（Kotlin Spring Boot × React/TS）
+
+| #   | Method | Path                     | 説明                         | 認証   |
+| --- | ------ | ------------------------ | ---------------------------- | ------ |
+| A1  | POST   | /auth/signup             | 新規登録                     | なし   |
+| A2  | POST   | /auth/login              | ログイン                     | なし   |
+| A3  | POST   | /auth/refresh            | リフレッシュトークンで再発行 | なし   |
+| U1  | GET    | /users/me                | 自分のプロフィール取得       | 要 JWT |
+| U2  | PATCH  | /users/me                | 自分のプロフィール更新       | 要 JWT |
+| P1  | POST   | /posts                   | 汚部屋投稿作成（写真＋説明） | 要 JWT |
+| P2  | GET    | /posts                   | 投稿一覧                     | 任意   |
+| P3  | GET    | /posts/{postId}          | 投稿詳細                     | 任意   |
+| P4  | DELETE | /posts/{postId}          | 自分の投稿削除               | 要 JWT |
+| R2  | GET    | /posts/{postId}/ratings  | 平均評価取得                 | 要 JWT |
+| C1  | POST   | /posts/{postId}/comments | コメント作成                 | 要 JWT |
+| C2  | GET    | /posts/{postId}/comments | コメント一覧                 | 任意   |
+| H1  | GET    | /health                  | ヘルスチェック               | なし   |

--- a/docs/ER_DIAGRAM.md
+++ b/docs/ER_DIAGRAM.md
@@ -1,0 +1,54 @@
+# ER 図
+
+```mermaid
+erDiagram
+    users ||--o| profiles : "has"
+
+    users {
+        uuid id PK "ユーザーID"
+        string email UK "メールアドレス"
+        timestamp created_at "作成日時"
+        timestamp updated_at "更新日時"
+    }
+
+    profiles {
+        uuid id PK "プロフィールID"
+        uuid user_id FK "ユーザーID"
+        string nickname "ニックネーム (1-50文字)"
+        string avatar_url "アイコン画像URL (S3/MinIO)"
+        string bio "自己紹介文 (最大500文字)"
+        timestamp created_at "作成日時"
+        timestamp updated_at "更新日時"
+    }
+```
+
+## テーブル説明
+
+### users テーブル
+
+認証情報を管理するテーブル
+
+- `id`: ユーザーの一意識別子（UUID）
+- `email`: ログインに使用するメールアドレス（一意制約）
+- `created_at`: アカウント作成日時
+- `updated_at`: 最終更新日時
+
+### profiles テーブル
+
+ユーザーのプロフィール情報を管理するテーブル
+
+- `id`: プロフィールの一意識別子（UUID）
+- `user_id`: users テーブルへの外部キー
+- `nickname`: 表示名（1-50 文字、バリデーション必要）
+- `avatar_url`: S3/MinIO に保存されたアイコン画像の URL
+- `bio`: 自己紹介文（最大 500 文字）
+- `created_at`: プロフィール作成日時
+- `updated_at`: 最終更新日時
+
+## 関連エンドポイント
+
+- `GET /users/me` (U1): 自分のプロフィール取得
+- `PUT /users/me` (U2): 自分のプロフィール更新
+- `POST /users/me/avatar` (U3): アイコン画像アップロード
+- `DELETE /users/me/avatar` (U4): アイコン削除
+- `GET /users/{userId}` (U5): 他ユーザーのプロフィール取得

--- a/docs/FORMATTING.md
+++ b/docs/FORMATTING.md
@@ -1,34 +1,7 @@
-# コードフォーマット設定
-
-このプロジェクトではコードスタイルの統一のため、**ktlint**を使用しています。
-
 ## 概要
 
 - **フォーマッター**: [ktlint](https://github.com/pinterest/ktlint) v1.0.1
-- **スタイルガイド**: Kotlin公式スタイルガイド準拠
-- **自動チェック**: GitHub Actions（PR時）
-
----
-
-## セットアップ
-
-### 必要なもの
-
-- JDK 21
-- Gradle（プロジェクトに含まれています）
-
-### 初回セットアップ
-
-```bash
-# リポジトリをクローン
-git clone <repository-url>
-cd oby-backend
-
-# 依存関係をダウンロード（ktlintも自動的にセットアップされます）
-./gradlew build
-```
-
----
+- **自動チェック**: GitHub Actions（PR 時）
 
 ## 使い方
 
@@ -38,153 +11,12 @@ cd oby-backend
 ./gradlew ktlintCheck
 ```
 
-違反がある場合、エラーメッセージとファイル/行番号が表示されます。
-
 ### 自動修正
 
 ```bash
 ./gradlew ktlintFormat
 ```
 
-自動修正可能な違反は全て修正されます。
+### Q: なぜ Prettier ではなく ktlint を使うのですか？
 
-### 特定のソースセットのみチェック
-
-```bash
-./gradlew ktlintMainSourceSetCheck    # src/main のみ
-./gradlew ktlintTestSourceSetCheck    # src/test のみ
-```
-
----
-
-## 推奨ワークフロー
-
-### 開発中
-
-1. コードを書く
-2. 保存時にエディタが自動フォーマット（推奨設定は下記参照）
-
-### コミット前
-
-```bash
-./gradlew ktlintFormat
-```
-
-コミット前に実行して違反を修正しておくと、CIで失敗しません。
-
-### PR作成前
-
-```bash
-./gradlew ktlintCheck
-```
-
-すべてのチェックがパスすることを確認してからPRを作成してください。
-
----
-
-## エディタ設定
-
-### IntelliJ IDEA / Android Studio
-
-1. **設定** → **Editor** → **Code Style** → **Kotlin**
-2. **Set from...** → **Predefined Style** → **Kotlin style guide**
-3. **Apply** をクリック
-
-`.editorconfig`が自動的に認識されるため、追加設定は不要です。
-
-### VSCode
-
-拡張機能をインストール：
-```
-Name: Kotlin
-Publisher: mathiasfrohlich
-```
-
-`.editorconfig`が自動的に認識されます。
-
-### Neovim / Vim
-
-`.editorconfig`が自動的に認識されます（`editorconfig-vim`プラグインが必要な場合があります）。
-
----
-
-## CI/CD（GitHub Actions）
-
-### 自動チェック
-
-PR作成時やmain/masterブランチへのpush時に、自動的に`ktlintCheck`が実行されます。
-
-### チェックが失敗した場合
-
-1. GitHub Actionsのログでエラーメッセージを確認
-2. ローカルで`./gradlew ktlintFormat`を実行
-3. 修正をコミット・push
-
-### レポートの確認
-
-チェックが失敗した場合、GitHub ActionsのArtifactsからktlintレポートをダウンロードできます：
-
-1. GitHub Actionsのワークフロー実行ページへ移動
-2. **Artifacts**セクションから`ktlint-reports`をダウンロード
-3. テキストファイルで詳細な違反内容を確認
-
----
-
-## よくある質問
-
-### Q: ktlintのルールを無効化できますか？
-
-A: 可能ですが、推奨しません。チーム全体のコードスタイル統一のため、公式スタイルガイドに従うことを推奨します。
-
-どうしても必要な場合は、`build.gradle.kts`の`ktlint`セクションで設定できます。
-
-### Q: なぜPrettierではなくktlintを使うのですか？
-
-A: Prettierはweb開発言語（JavaScript/TypeScript等）専用です。KotlinプロジェクトにはKotlin公式のktlintが最適です。
-
-### Q: フォーマットを自動で行いたくない場合は？
-
-A: GitHub Actionsのチェックはスキップできませんが、ローカルでは`ktlintCheck`のみ実行して手動修正することも可能です。
-
-### Q: コミット時に自動でフォーマットされるようにできますか？
-
-A: Git Hooksを使えば可能です。今後導入を検討しています。
-
----
-
-## 参考リンク
-
-- [ktlint公式ドキュメント](https://pinterest.github.io/ktlint/)
-- [Kotlin公式スタイルガイド](https://kotlinlang.org/docs/coding-conventions.html)
-- [ktlint Gradleプラグイン](https://github.com/JLLeitschuh/ktlint-gradle)
-
----
-
-## トラブルシューティング
-
-### `./gradlew ktlintCheck`が遅い
-
-初回実行時はktlintのダウンロードに時間がかかります。2回目以降は高速です。
-
-### チェックが通らない
-
-```bash
-# レポートファイルを確認
-cat build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt
-```
-
-詳細なエラー内容が記載されています。
-
-### Gradleのキャッシュをクリアしたい
-
-```bash
-./gradlew clean
-rm -rf .gradle build
-./gradlew build
-```
-
----
-
-## サポート
-
-フォーマット設定に関する質問や問題があれば、Issueを作成するか、チームメンバーに相談してください。
+A: Prettier は web 開発言語（JavaScript/TypeScript 等）専用です。Kotlin プロジェクトには Kotlin 公式の ktlint が最適です。

--- a/docs/FORMATTING.md
+++ b/docs/FORMATTING.md
@@ -17,6 +17,6 @@
 ./gradlew ktlintFormat
 ```
 
-### Q: なぜ Prettier ではなく ktlint を使うのですか？
+### Q: なぜ主に Prettier ではなく ktlint を使うのですか？
 
 A: Prettier は web 開発言語（JavaScript/TypeScript 等）専用です。Kotlin プロジェクトには Kotlin 公式の ktlint が最適です。

--- a/docs/orval-api-guidelines.md
+++ b/docs/orval-api-guidelines.md
@@ -1,29 +1,9 @@
-# Orval連携のためのAPI設計ガイドライン
+# Orval 連携のための API 設計ガイドライン
 
-このドキュメントは、フロントエンドのorvalと連携するために、バックエンドのAPI実装で必要な設定とベストプラクティスをまとめたものです。
+- OpenAPI JSON: `http://localhost:8080/v3/api-docs`
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
 
-## 必須設定
-
-### 1. SpringDoc依存関係
-
-`build.gradle.kts`に以下の依存関係を追加してください：
-
-```kotlin
-implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
-```
-
-### 2. application.properties設定
-
-```properties
-# OpenAPI / Swagger Configuration
-springdoc.api-docs.path=/v3/api-docs
-springdoc.swagger-ui.path=/swagger-ui.html
-springdoc.swagger-ui.operationsSorter=method
-```
-
-## Controllerでの必須アノテーション
-
-orvalが正しく型を生成するために、以下のアノテーションを**必ず**付与してください。
+## Controller での必須アノテーション
 
 ### @Tag（Controller クラスレベル）
 
@@ -34,9 +14,8 @@ orvalが正しく型を生成するために、以下のアノテーションを
 class MessageController { ... }
 ```
 
-- **目的**: APIをグループ化し、orvalの`mode: 'tags'`で適切にファイル分割される
-- **必須**: はい
-- **name**: orvalが生成するファイル名の基準になるため、明確で一貫性のある名前を使用
+- orval の `mode: 'tags'` で適切にファイル分割される
+- `name` は orval が生成するファイル名の基準になる
 
 ### @Operation（メソッドレベル）
 
@@ -46,93 +25,21 @@ class MessageController { ... }
 fun getMessage(@PathVariable id: UUID): ResponseEntity<Message>
 ```
 
-- **目的**: orvalが生成する関数名を制御
-- **必須**: はい
-- **operationId**: orvalが生成する関数名になるため、**必ず明示的に指定すること**
-  - 未指定の場合、自動生成された名前になり予測不可能
-  - キャメルケースで記述（例: `getMessageById`, `createMessage`, `listMessages`）
-  - プロジェクト全体でユニークな名前を使用
-- **summary**: 任意だが、API一覧での可読性向上のため推奨
+- `operationId` を**必ず明示的に指定**（orval が生成する関数名になる）
+- キャメルケースで記述（例: `getMessageById`, `createMessage`, `listMessages`）
+- プロジェクト全体でユニークな名前を使用
 
-## DTOでの必須アノテーション
-
-### @Schema（クラス/プロパティレベル）
+### @Schema（DTO クラス/プロパティレベル）
 
 ```kotlin
 @Schema(description = "メッセージエンティティ")
 data class Message(
-    @Schema(description = "メッセージ本文", example = "Hello, World!", required = true)
+    @Schema(description = "メッセージ本文", required = true)
     val text: String,
 
-    @Schema(description = "メッセージID（自動生成）", example = "123e4567-e89b-12d3-a456-426614174000")
+    @Schema(description = "メッセージID")
     val id: UUID? = null
 )
 ```
 
-- **目的**: プロパティの型情報、説明、例を明示
-- **必須**: はい
-- **required**: プロパティが必須かどうかを明示（orvalの型で`string`か`string | undefined`かが決まる）
-- **example**: Swagger UIでの表示とテストに使用される
-
-## orval設定例（フロントエンド側）
-
-```typescript
-import { defineConfig } from 'orval';
-
-export default defineConfig({
-  oby: {
-    input: 'http://localhost:8080/v3/api-docs',
-    output: {
-      target: 'src/api/generated',
-      mode: 'tags',  // @Tagでグループ化
-      client: 'react-query',
-      httpClient: 'fetch',
-      baseUrl: '/api',
-    },
-  },
-});
-```
-
-## チェックリスト
-
-新しいAPIエンドポイントを追加する際は、以下を確認してください：
-
-- [ ] Controllerに`@Tag`が付与されている
-- [ ] すべてのエンドポイントメソッドに`@Operation`が付与されている
-- [ ] すべての`@Operation`に**明示的な`operationId`**が設定されている
-- [ ] リクエスト/レスポンスで使用するDTOに`@Schema`が付与されている（任意：プロパティの説明が必要な場合）
-
-## 動作確認
-
-以下のURLでOpenAPI仕様とSwagger UIを確認できます：
-
-- OpenAPI JSON: `http://localhost:8080/v3/api-docs`
-- Swagger UI: `http://localhost:8080/swagger-ui.html`
-
-アプリケーション起動後、上記URLにアクセスして正しくAPI仕様が生成されていることを確認してください。
-
-## トラブルシューティング
-
-### orvalで関数名が予期しないものになる
-
-**原因**: `operationId`が未指定または重複している
-
-**解決策**: すべての`@Operation`に明示的で一意な`operationId`を設定する
-
-### orvalで生成される型が間違っている
-
-**原因**: DTOのプロパティがnullableかどうかが正しく反映されていない
-
-**解決策**: Kotlinの型（`String`か`String?`か）を正しく設定する。SpringDocが自動的に型情報を検出します
-
-### orvalでファイルが適切に分割されない
-
-**原因**: `@Tag`が未指定または一貫性がない
-
-**解決策**: すべてのControllerに適切な`@Tag(name = "...")`を設定
-
-## 参考リンク
-
-- [SpringDoc OpenAPI Documentation](https://springdoc.org/)
-- [Orval Documentation](https://orval.dev/)
-- [Swagger Annotations](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations)
+- `required` でプロパティが必須かを明示（orval の型で `string` か `string | undefined` かが決まる）


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #
まだクローズしない

## やったこと

ドキュメントの整備
まずは #4 のタスクをやるためのドキュメントを整備
エンドポイントはほとんど記載。細かい変更があるかもしれません
ER図はusersの認証・認可関連のテーブルは最小限にてきとーにかいて
profilesテーブルはこれで行こうと思う。

## 動作確認
<!-- テスト内容など -->
- [ ] ビルドできた

## 参考にした資料

<!-- for GitHub Copilot review rule -->
レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けてください。
[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->
